### PR TITLE
Fix YACL and lazyyyyy game freeze

### DIFF
--- a/run/config/lazyyyyy.mixins.json
+++ b/run/config/lazyyyyy.mixins.json
@@ -6,7 +6,7 @@
     "lazy_entity_renderers": false,
     "moremcmeta.avoid_duplicate_sprites": true,
     "toomanyplayers.async_networking": true,
-    "yacl.lazy_animated_image": true,
+    "yacl.lazy_animated_image": false,
     "kiwi.faster_annotation": true,
     "pack_resources_cache": true,
     "avoid_redundant_list_resources": true


### PR DESCRIPTION
There is a conflict between [lazyyyyy and YACL](https://github.com/SettingDust/lazyyyyy/issues/88) as [documented in the mod description](https://github.com/echoEllet/controlify#-incompatible-mods).

You can launch the game with Controlify, but when opening the Controlify config screen (YACL), the game will freeze.

This modpack uses this lazyyyyy. A Workaround for now is (while we wait for an official fix) is to disable YAZL lazy image loading by updating `config/lazyyyyy.mixins.json`:

```json
{
    "yacl.lazy_animated_image": false,
}
```

> This shouldn't cause issues for other mods, because the only mod that uses YACL is Controlify.